### PR TITLE
Adapt 1105

### DIFF
--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -7,6 +7,8 @@
  */
 define(function(require) {
 
+  require('./xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var Backbone = require('backbone');
   var _ = require('underscore');
@@ -15,7 +17,6 @@ define(function(require) {
   var ComponentStatementModel = require('./models/component-statement');
   var QuestionComponentStatementModel = require('./models/question-component-statement');
   var MCQComponentStatementModel = require('./models/mcq-component-statement');
-  var ADL = require('./xapiwrapper.min');
 
   var xapiWrapper;
   var STATE_PROGRESS = 'adapt-course-progress';

--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -123,7 +123,7 @@ define(function(require) {
           statementModel = new MCQComponentStatementModel(data);
           break;
         default:
-          statementModel = null;
+          statementModel = new QuestionComponentStatementModel(data);
           break;
       }
 

--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -15,7 +15,7 @@ define(function(require) {
   var ComponentStatementModel = require('./models/component-statement');
   var QuestionComponentStatementModel = require('./models/question-component-statement');
   var MCQComponentStatementModel = require('./models/mcq-component-statement');
-  var ADL = require('adapt-xapi.js/./xapiwrapper.min');
+  var ADL = require('./xapiwrapper.min');
 
   var xapiWrapper;
   var STATE_PROGRESS = 'adapt-course-progress';

--- a/js/models/assessment-statement.js
+++ b/js/models/assessment-statement.js
@@ -3,6 +3,7 @@ define(function(require) {
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
+  var ADL = require('../xapiwrapper.min');
   var StatementModel = require('./statement');
 
   var AssessmentStatementModel = StatementModel.extend({

--- a/js/models/assessment-statement.js
+++ b/js/models/assessment-statement.js
@@ -11,8 +11,8 @@ define(function(require) {
       return StatementModel.prototype.initialize.call(this);
     },
 
-    getStatementObject: function() {
-      var statement = StatementModel.prototype.getStatementObject.call(this);
+    getStatement: function() {
+      var statement = StatementModel.prototype.getStatement.call(this);
 
       var verb = this.getVerb();
       var object = this.getObject();

--- a/js/models/assessment-statement.js
+++ b/js/models/assessment-statement.js
@@ -1,9 +1,10 @@
 define(function(require) {
 
+  require('../xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../xapiwrapper.min');
   var StatementModel = require('./statement');
 
   var AssessmentStatementModel = StatementModel.extend({

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -2,6 +2,8 @@ define(function(require) {
 
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
+  var Backbone = require('backbone');
+  var ADL = require('../xapiwrapper.min');
   var StatementModel = require('./statement');
 
   return StatementModel.extend({

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -1,9 +1,10 @@
 define(function(require) {
 
+  require('../xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../xapiwrapper.min');
   var StatementModel = require('./statement');
 
   return StatementModel.extend({

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -41,17 +41,12 @@ define(function(require) {
       return StatementModel.prototype.getObject.call(this);
     },
 
-    getActivityDefinitionObject: function() {
-      var object = StatementModel.prototype.getActivityDefinitionObject.call(this);
+    getObject: function() {
+      var object = StatementModel.prototype.getObject.call(this);
 
-      if (_.isEmpty(object)) {
-        object = {};
-      }
+      object.id = ['http://adaptlearning.org', this.get('model').get('_type'), this.get('model').get('_component')].join('/');
 
-      object.name = {};
-      object.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
-
-      object.type = ['http://adaptlearning.org', this.get('model').get('_type'), this.get('model').get('_component')].join('/');
+      object.definition.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
 
       return object;
     },

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -2,17 +2,16 @@ define(function(require) {
 
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
-  var Backbone = require('backbone');
   var StatementModel = require('./statement');
 
-  var ComponentStatementModel = StatementModel.extend({
+  return StatementModel.extend({
 
     initialize: function() {
       return StatementModel.prototype.initialize.call(this);
     },
 
-    getStatementObject: function() {
-      var statement = StatementModel.prototype.getStatementObject.call(this);
+    getStatement: function() {
+      var statement = StatementModel.prototype.getStatement.call(this);
 
       var verb = this.getVerb();
       var object = this.getObject();
@@ -35,10 +34,6 @@ define(function(require) {
 
     getVerb: function() {
       return StatementModel.prototype.getVerb.call(this);
-    },
-
-    getObject: function() {
-      return StatementModel.prototype.getObject.call(this);
     },
 
     getObject: function() {
@@ -99,10 +94,8 @@ define(function(require) {
       }
 
       return contextActivities;
-    },
+    }
 
   });
-
-  return ComponentStatementModel;
 
 });

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -36,11 +36,25 @@ define(function(require) {
     },
 
     getVerb: function() {
-      return StatementModel.prototype.getVerb.call(this);
+      var verb = StatementModel.prototype.getVerb.call(this);
+
+      if (
+        _.isNull(verb)
+      ) {
+        return null;
+      }
+
+      return verb;
     },
 
     getObject: function() {
       var object = StatementModel.prototype.getObject.call(this);
+
+      if (
+        _.isNull(object)
+      ) {
+        return null;
+      }
 
       object.id = ['http://adaptlearning.org', this.get('model').get('_type'), this.get('model').get('_component')].join('/');
 

--- a/js/models/component-statement.js
+++ b/js/models/component-statement.js
@@ -76,13 +76,24 @@ define(function(require) {
       }
 
       if (this.get('model').get('_isPartOfAssessment') == true) {
+        // Parent is the assessment
         // component -> block -> article
         var article = this.get('model').getParent().getParent();
 
         if (!_.isEmpty(article)) {
           var assessmentIri = [this.get('activityId'), 'assessment', article.get('_id')].join('/');
           contextActivities.parent = {
-            id : assessmentIri
+            id: assessmentIri
+          }
+        }
+      } else {
+        // Parent is the course
+        // component -> block -> article -> page -> course
+        var course = this.get('model').getParent().getParent().getParent().getParent();
+        if (!_.isEmpty(course)) {
+          var courseIri = [this.get('activityId'), 'course', course.get('_id')].join('/');
+          contextActivities.parent = {
+            id: courseIri
           }
         }
       }

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -11,8 +11,8 @@ define(function(require) {
       return QuestionComponentStatementModel.prototype.initialize.call(this);
     },
 
-    getStatementObject: function() {
-      var statement = QuestionComponentStatementModel.prototype.getStatementObject.call(this);
+    getStatement: function() {
+      var statement = QuestionComponentStatementModel.prototype.getStatement.call(this);
 
       var verb = this.getVerb();
       var object = this.getObject();

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -43,7 +43,29 @@ define(function(require) {
     },
 
     getObject: function() {
-      return QuestionComponentStatementModel.prototype.getObject.call(this);
+      var object = QuestionComponentStatementModel.prototype.getObject.call(this);
+      
+      if (
+        _.isNull(object)
+      ) {
+        return null;
+      }
+
+      object.definition.interactionType = "choice";
+
+      object.definition.correctResponsePattern = "";
+      var correctResponses = [];
+      _.each(this.get('model').get('_items'), function(item) {
+        if (item._shouldBeSelected) {
+          correctResponses.push(item._index);
+        }
+      });
+
+      object.definition.correctResponsePattern = correctResponses.join("[,]");
+
+      object.definition.choices = this.getDefinitionChoices();
+
+      return object;
     },
 
     getResult: function() {

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -1,9 +1,10 @@
 define(function(require) {
 
+  require('../xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../xapiwrapper.min');
   var QuestionComponentStatementModel = require('./question-component-statement');
 
   var MCQComponentStatementModel = QuestionComponentStatementModel.extend({

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -69,12 +69,15 @@ define(function(require) {
 
       object.definition.interactionType = "choice";
 
-      object.definition.correctResponsePattern = [];
+      object.definition.correctResponsePattern = "";
+      var correctResponses = [];
       _.each(this.get('model').get('_items'), function(item) {
         if (item._shouldBeSelected) {
-          object.definition.correctResponsePattern.push(item._index);
+          correctResponses.push(item._index);
         }
       });
+
+      object.definition.correctResponsePattern = correctResponses.join("[,]");
 
       object.definition.choices = this.getDefinitionChoices();
 

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -1,0 +1,109 @@
+define(function(require) {
+
+  var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var QuestionComponentStatementModel = require('./question-component-statement');
+
+  var MCQComponentStatementModel = QuestionComponentStatementModel.extend({
+
+    initialize: function() {
+      return QuestionComponentStatementModel.prototype.initialize.call(this);
+    },
+
+    getStatementObject: function() {
+      var statement = QuestionComponentStatementModel.prototype.getStatementObject.call(this);
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+      var result = this.getResult();
+
+      if (
+        _.isEmpty(verb) ||
+        _.isEmpty(object) ||
+        _.isEmpty(context) ||
+        _.isEmpty(result)
+      ) {
+        return null;
+      }
+
+      statement.verb = verb;
+      statement.object = object;
+      statement.context = context;
+      statement.result = result;
+
+      return statement;
+    },
+
+    getVerb: function() {
+      return QuestionComponentStatementModel.prototype.getVerb.call(this);
+    },
+
+    getObject: function() {
+      return QuestionComponentStatementModel.prototype.getObject.call(this);
+    },
+
+    getResult: function() {
+      var result = QuestionComponentStatementModel.prototype.getResult.call(this);
+
+      result.response = [];
+      _.each(this.get('model').get('_selectedItems'), function(item) {
+        result.response.push(item._index);
+      });
+
+      return result;
+    },
+
+    getScore: function() {
+      var score = QuestionComponentStatementModel.prototype.getScore.call(this);
+
+      // MCQ is either 0 or 1
+      score.scaled = score.raw;
+
+      return score;
+    },
+
+    getObject: function() {
+      var object = QuestionComponentStatementModel.prototype.getObject.call(this);
+
+      object.definition.interactionType = "choice";
+
+      object.definition.correctResponsePattern = [];
+      _.each(this.get('model').get('_items'), function(item) {
+        if (item._shouldBeSelected) {
+          object.definition.correctResponsePattern.push(item._index);
+        }
+      });
+
+      object.definition.choices = this.getDefinitionChoices();
+
+      return object;
+    },
+
+    getDefinitionChoices: function() {
+      var choices = [];
+
+      if (
+        _.isEmpty(this.get('model').get('_items'))
+      ) {
+        return null;
+      }
+
+      _.each(this.get('model').get('_items'), function(item) {
+        var choice = {};
+        choice.id = item._index;
+        choice.description = {};
+        choice.description[Adapt.config.get('_defaultLanguage')] = item.text;
+
+        choices.push(choice);
+      });
+
+      return choices;
+    },
+
+  });
+
+  return MCQComponentStatementModel;
+
+});

--- a/js/models/mcq-component-statement.js
+++ b/js/models/mcq-component-statement.js
@@ -3,6 +3,7 @@ define(function(require) {
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
+  var ADL = require('../xapiwrapper.min');
   var QuestionComponentStatementModel = require('./question-component-statement');
 
   var MCQComponentStatementModel = QuestionComponentStatementModel.extend({

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -2,8 +2,9 @@ define(function(require) {
 
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
+  var Backbone = require('backbone');
+  var ADL = require('../xapiwrapper.min');
   var ComponentStatementModel = require('./component-statement');
-  var ADL = require('question-component-statement.js/../../xapiwrapper.min');
 
   return ComponentStatementModel.extend({
 

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -1,0 +1,93 @@
+define(function(require) {
+
+  var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var ComponentStatementModel = require('./component-statement');
+
+  var QuestionComponentStatementModel = ComponentStatementModel.extend({
+
+    initialize: function() {
+      return ComponentStatementModel.prototype.initialize.call(this);
+    },
+
+    getStatementObject: function() {
+      var statement = ComponentStatementModel.prototype.getStatementObject.call(this);
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+      var result = this.getResult();
+
+      if (
+        _.isEmpty(verb) ||
+        _.isEmpty(object) ||
+        _.isEmpty(context) ||
+        _.isEmpty(result)
+      ) {
+        return null;
+      }
+
+      statement.verb = verb;
+      statement.object = object;
+      statement.context = context;
+      statement.result = result;
+
+      return statement;
+    },
+
+    getVerb: function() {
+      return ADL.verbs.answered;
+    },
+
+    getObject: function() {
+      var object = ComponentStatementModel.prototype.getObject.call(this);
+
+      object.definition.type = "http://adlnet.gov/expapi/activities/cmi.interaction";
+
+      return object;
+    },
+
+    getResult: function() {
+      var result = {};
+
+      var score = this.getScore();
+      if (score != null) {
+        result.score = score;
+      }
+
+      if (this.get('model').isCorrect != null) {
+        result.success = this.get('model').isCorrect;
+      }
+
+      if (this.get('model').isComplete != null) {
+        result.completion = this.get('model').isComplete;
+      }
+
+      return result;
+    },
+
+    getScore: function() {
+      var score = {};
+
+      score.raw = this.get('model').get('_score');
+
+      return score;
+    },
+
+    getObject: function() {
+      var object = ComponentStatementModel.prototype.getObject.call(this);
+
+      object.type = this.get('model').get('_component');
+
+      object.definition.description = {};
+      object.definition.description[Adapt.config.get('_defaultLanguage')] = this.get('model').get('body');
+
+      return object;
+    },
+
+  });
+
+  return QuestionComponentStatementModel;
+
+});

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -2,17 +2,17 @@ define(function(require) {
 
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
-  var Backbone = require('backbone');
   var ComponentStatementModel = require('./component-statement');
+  var ADL = require('question-component-statement.js/../../xapiwrapper.min');
 
-  var QuestionComponentStatementModel = ComponentStatementModel.extend({
+  return ComponentStatementModel.extend({
 
     initialize: function() {
       return ComponentStatementModel.prototype.initialize.call(this);
     },
 
-    getStatementObject: function() {
-      var statement = ComponentStatementModel.prototype.getStatementObject.call(this);
+    getStatement: function() {
+      var statement = ComponentStatementModel.prototype.getStatement.call(this);
 
       var verb = this.getVerb();
       var object = this.getObject();
@@ -45,6 +45,8 @@ define(function(require) {
 
       object.definition.type = "http://adlnet.gov/expapi/activities/cmi.interaction";
 
+      object.definition.description[Adapt.config.get('_defaultLanguage')] = this.get('model').get('body');
+
       return object;
     },
 
@@ -73,21 +75,8 @@ define(function(require) {
       score.raw = this.get('model').get('_score');
 
       return score;
-    },
-
-    getObject: function() {
-      var object = ComponentStatementModel.prototype.getObject.call(this);
-
-      object.type = this.get('model').get('_component');
-
-      object.definition.description = {};
-      object.definition.description[Adapt.config.get('_defaultLanguage')] = this.get('model').get('body');
-
-      return object;
-    },
+    }
 
   });
-
-  return QuestionComponentStatementModel;
 
 });

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -56,12 +56,12 @@ define(function(require) {
         result.score = score;
       }
 
-      if (this.get('model').isCorrect != null) {
-        result.success = this.get('model').isCorrect;
+      if (this.get('model').get('_isCorrect') != null) {
+        result.success = this.get('model').get('_isCorrect');
       }
 
-      if (this.get('model').isComplete != null) {
-        result.completion = this.get('model').isComplete;
+      if (this.get('model').get('_isComplete') != null) {
+        result.completion = this.get('model').get('_isComplete');
       }
 
       return result;

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -1,9 +1,10 @@
 define(function(require) {
 
+  require('../xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../xapiwrapper.min');
   var ComponentStatementModel = require('./component-statement');
 
   return ComponentStatementModel.extend({

--- a/js/models/question-component-statement.js
+++ b/js/models/question-component-statement.js
@@ -45,6 +45,12 @@ define(function(require) {
     getObject: function() {
       var object = ComponentStatementModel.prototype.getObject.call(this);
 
+      if (
+        _.isNull(object)
+      ) {
+        return null;
+      }
+
       object.definition.type = "http://adlnet.gov/expapi/activities/cmi.interaction";
 
       object.definition.description[Adapt.config.get('_defaultLanguage')] = this.get('model').get('body');

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -1,8 +1,9 @@
 define(function(require) {
 
   var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../../xapiwrapper.min');
+  var ADL = require('../xapiwrapper.min');
 
   /**
    * @typedef   {Object}      xAPI.Statement            The Statement is the core of the xAPI. All learning events are stored as Statements. A Statement is akin to a sentence of the form "I did this".

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -79,20 +79,20 @@ define(function(require) {
 
       object.objectType = "Activity";
 
-      object.definition = this.getActivityDefinitionObject(this.get('model'));
+      object.definition = this.getObjectDefinition(this.get('model'));
 
       return object;
     },
 
-    getActivityDefinitionObject: function() {
-      var object = {};
+    getObjectDefinition: function() {
+      var objectDefinition = {};
 
-      object.name = {};
-      object.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
+      objectDefinition.name = {};
+      objectDefinition.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
 
-      object.type = this.get('model').get('_type');
+      objectDefinition.type = this.get('model').get('_type');
 
-      return object;
+      return objectDefinition;
     },
 
     getContext: function() {

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -1,16 +1,53 @@
 define(function(require) {
 
   var Adapt = require('coreJS/adapt');
-  var _ = require('underscore');
   var Backbone = require('backbone');
+  var ADL = require('../../xapiwrapper.min');
 
-  var StatementModel = Backbone.Model.extend({
+  /**
+   * @typedef   {Object}      xAPI.Statement            The Statement is the core of the xAPI. All learning events are stored as Statements. A Statement is akin to a sentence of the form "I did this".
+   * @property  {Object}      xAPI.Statement.actor      Who the Statement is about, as an Agent or Group Object. Represents the "I" in "I Did This".
+   * @property  {xAPI.Verb}   xAPI.Statement.verb       Action of the Learner or Team Object. Represents the "Did" in "I Did This".
+   * @property  {xAPI.Object} xAPI.Statement.object     Activity, Agent, or another Statement that is the Object of the Statement. Represents the "This" in "I Did This".
+   * @property  {Object}      [xAPI.Statement.result]   Result Object, further details representing a measured outcome relevant to the specified Verb.
+   * @property  {Object}      [xAPI.Statement.context]  Context that gives the Statement more meaning. Examples: a team the Actor is working with, altitude at which a scenario was attempted in a flight simulator.
+   */
+
+  /**
+   * @typedef   {Object}            xAPI.Verb            The Verb defines the action between Actor and Activity.
+   * @property  {xAPI.IRI}          xAPI.Verb.id         Corresponds to a Verb definition. Each Verb definition corresponds to the meaning of a Verb, not the word. The IRI should be human-readable and contain the Verb meaning.
+   * @property  {xAPI.LanguageMap}  [xAPI.Verb.display]  The human readable representation of the Verb in one or more languages. This does not have any impact on the meaning of the Statement, but serves to give a human-readable display of the meaning already determined by the chosen Verb.
+   */
+
+  /**
+   * @typedef   {Object}                          xAPI.Object              The Object of a Statement can be an Activity, Agent/Group, Sub-Statement, or Statement Reference. It is the "this" part of the Statement, i.e. "I did this".
+   * @property  {xAPI.IRI}                        xAPI.Object.id           An identifier for a single unique Activity
+   * @property  {string}                          [xAPI.Object.objectType] MUST be "Activity" when present and subject is an Activity
+   * @property  {xAPI.Object.ActivityDefinition}  [xAPI.Object.definition] The human readable representation of the Verb in one or more languages. This does not have any impact on the meaning of the Statement, but serves to give a human-readable display of the meaning already determined by the chosen Verb.
+   */
+
+  /**
+   * @typedef   {Object}            xAPI.Object.ActivityDefinition
+   * @property  {xAPI.LanguageMap}  [xAPI.Object.ActivityDefinition.name]         The human readable/visual name of the Activity
+   * @property  {xAPI.LanguageMap}  [xAPI.Object.ActivityDefinition.description]  A description of the Activity
+   * @property  {xAPI.IRI}          [xAPI.Object.ActivityDefinition.type]         The type of Activity
+   */
+
+  /**
+   * @typedef Object.<string, string> xAPI.LanguageMap
+   */
+
+  /**
+   * @typedef string xAPI.IRI
+   */
+
+  return Backbone.Model.extend({
 
     defaults: {
       activityId: null,
       actor: null,
       registration: null,
-      model: null,
+      model: null
     },
 
     initialize: function() {
@@ -30,8 +67,11 @@ define(function(require) {
         return null;
       }
     },
-
-    getStatementObject: function() {
+    /**
+     * Returns the Statement object itself or null if any of its required components are invalid
+     * @returns {xAPI.Statement|null}
+     */
+    getStatement: function() {
       var statement = {};
 
       var verb = this.getVerb();
@@ -63,10 +103,18 @@ define(function(require) {
       return statement;
     },
 
+    /**
+     * Returns an Verb for this Statement
+     * @returns {xAPI.Verb}
+     */
     getVerb: function() {
       return ADL.verbs.experienced;
     },
 
+    /**
+     * Returns an Object object for this Statement
+     * @returns {xAPI.Object|null}
+     */
     getObject: function() {
       var object = {};
 
@@ -79,12 +127,16 @@ define(function(require) {
 
       object.objectType = "Activity";
 
-      object.definition = this.getObjectDefinition(this.get('model'));
+      object.definition = this.getActivityDefinition();
 
       return object;
     },
 
-    getObjectDefinition: function() {
+    /**
+     * Returns a Definition object for this Statement
+     * @returns {xAPI.Object.ActivityDefinition}
+     */
+    getActivityDefinition: function() {
       var objectDefinition = {};
 
       objectDefinition.name = {};
@@ -92,9 +144,15 @@ define(function(require) {
 
       objectDefinition.type = this.get('model').get('_type');
 
+      objectDefinition.description = {};
+
       return objectDefinition;
     },
 
+    /**
+     * Returns a Context object for this Statement
+     * @returns {object}
+     */
     getContext: function() {
       var context = {};
 
@@ -116,6 +174,10 @@ define(function(require) {
       return context;
     },
 
+    /**
+     * Returns a contextActivities object for this Statement
+     * @returns {object}
+     */
     getContextActivities: function() {
       return {};
     },
@@ -126,10 +188,8 @@ define(function(require) {
       }
 
       return [this.get('activityId'), this.get('model').get('_type'), this.get('model').get('_id')].join('/');
-    },
+    }
 
   });
-
-  return StatementModel;
 
 });

--- a/js/models/statement.js
+++ b/js/models/statement.js
@@ -1,9 +1,10 @@
 define(function(require) {
 
+  require('../xapiwrapper.min');
+
   var Adapt = require('coreJS/adapt');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var ADL = require('../xapiwrapper.min');
 
   /**
    * @typedef   {Object}      xAPI.Statement            The Statement is the core of the xAPI. All learning events are stored as Statements. A Statement is akin to a sentence of the form "I did this".


### PR DESCRIPTION
Implemented a text input statement model which now sends an xAPI statement.

I'm not certain about the correctResponsePattern. There is an example for long-fill-in in the spec which has {case_matters} and {lang} properties which are relvant for fill-in too, but I can't find detail anywhere that says it can be used in both.

https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#appendix-c-example-definitions-for-activities-of-type-cmiinteraction

Example statement here: https://slack-files.com/T02E1FAT8-F10KEMVK4-f32d76292f